### PR TITLE
Change library version parsing to use shell components

### DIFF
--- a/make/common.mak
+++ b/make/common.mak
@@ -370,21 +370,17 @@ ifdef VERSION_FILE
 # If not specified, find the various version components in the VERSION_FILE
 
   ifndef MAJOR_VERSION
-    MAJOR_VERSION:=$(strip $(subst \#define,, $(subst $(MAJOR_VERSION_DEFINE),,\
-                   $(shell grep "define *$(MAJOR_VERSION_DEFINE) *" $(VERSION_FILE)))))
+    MAJOR_VERSION:=$(shell cat "$(VERSION_FILE)" | grep "$(MAJOR_VERSION_DEFINE)" | sed 's/[\\t ][\\t ]*/ /g' | cut -f 3 -d ' ')
   endif
   ifndef MINOR_VERSION
-    MINOR_VERSION:=$(strip $(subst \#define,, $(subst $(MINOR_VERSION_DEFINE),,\
-                   $(shell grep "define *$(MINOR_VERSION_DEFINE)" $(VERSION_FILE)))))
+    MINOR_VERSION:=$(shell cat "$(VERSION_FILE)" | grep "$(MINOR_VERSION_DEFINE)" | sed 's/[\\t ][\\t ]*/ /g' | cut -f 3 -d ' ')
   endif
   ifndef BUILD_TYPE
-    BUILD_TYPE:=$(strip $(subst \#define,,$(subst BUILD_TYPE,,\
-                $(subst AlphaCode,alpha,$(subst BetaCode,beta,$(subst ReleaseCode,.,\
-                $(shell grep "define *BUILD_TYPE" $(VERSION_FILE))))))))
+    BUILD_TYPE:=$(shell cat "$(VERSION_FILE)" | grep BUILD_TYPE | sed 's/[\\t ][\\t ]*/ /g' | cut -f 3 -d ' ' \
+                        | sed 's/AlphaCode/alpha/' | sed 's/BetaCode/beta/' | sed 's/ReleaseCode/./')
   endif
   ifndef BUILD_NUMBER
-    BUILD_NUMBER:=$(strip $(subst \#define,,$(subst $(BUILD_NUMBER_DEFINE),,\
-                  $(shell grep "define *$(BUILD_NUMBER_DEFINE)" $(VERSION_FILE)))))
+    BUILD_NUMBER:=$(shell cat "$(VERSION_FILE)" | grep "$(BUILD_NUMBER_DEFINE)" | sed 's/[\\t ][\\t ]*/ /g' | cut -f 3 -d ' ')
   endif
 
 # Finally check that version numbers are not empty


### PR DESCRIPTION
This fixes the build failure on Ubuntu 20.10, where the previous parsing would result in incorrect version components that included
the "#define" prefix.

For example:

```
MAJOR_VERSION=#define 2
MINOR_VERSION=#define 10
BUILD_NUMBER=#define 9
BUILD_TYPE=#define .
```
