### PR TITLE
Fix PThread::IsTerminated not working on glibc 2.34.

### DIFF
--- a/include/ptlib/thread.h
+++ b/include/ptlib/thread.h
@@ -373,6 +373,9 @@ class PThread : public PObject
   protected:
     bool   m_isProcess;
     bool   m_autoDelete; // Automatically delete the thread on completion.
+#if defined(P_PTHREADS)
+    bool   m_isRunning;
+#endif
     PINDEX m_originalStackSize;
 
     PString m_threadName; // Give the thread a name for debugging purposes.

--- a/include/ptlib/unix/ptlib/pprocess.h
+++ b/include/ptlib/unix/ptlib/pprocess.h
@@ -66,6 +66,10 @@ PDICTIONARY(PXFdDict, POrdinalKey, PThread);
     void CreateConfigFilesDictionary();
     PAbstractDictionary * configFiles;
 
+#if defined(P_PTHREADS)
+  public:
+    static void FinalizeThread(void*);
+#endif // defined(P_PTHREADS)
 
 #if defined(P_PTHREADS) || defined(P_MAC_MPTHREADS) || defined (__BEOS__)
 


### PR DESCRIPTION
In glibc 2.34 and possibly other implementations, `pthread_kill` does not return a `ESRCH` error if it is used on a thread that has ended execution. POSIX does not require the implementation to indicate error if the thread has terminated.

This affected `PThread::IsTerminated`, which relied on this behavior to detect if a thread has terminated. As a consequence, this broke thread termination, since `PThread::WaitForTermination` would just hang until timeout and report failure.

We use a separate flag to indicate whether the thread is running. The flag is set when `PThread` object is constructed with a running thread or starts a new thread. The flag is reset during TLS cleanup, which happens whether if the thread ends execution normally or is terminated with `pthread_cancel`. `PThread::IsTerminated` now relies on this new flag to track thread execution instead of `pthread_kill`.

Since `PThread::IsTerminated` can be called from different threads, accesses to the flag are made using atomic intrinsics, which are available since gcc 4.7 and clang 3.2.

Fixes https://github.com/willamowius/ptlib/issues/10.
