### PR TITLE
Disambiguate PString (in)equality operators

### DIFF
--- a/include/ptlib/contain.inl
+++ b/include/ptlib/contain.inl
@@ -116,7 +116,13 @@ PINLINE PString & PString::operator&=(const PString & str)
 PINLINE bool PString::operator==(const PObject & obj) const
   { return PObject::operator==(obj); }
 
+PINLINE bool PString::operator==(const PString & obj) const
+  { return PObject::operator==(obj); }
+
 PINLINE bool PString::operator!=(const PObject & obj) const
+  { return PObject::operator!=(obj); }
+
+PINLINE bool PString::operator!=(const PString & obj) const
   { return PObject::operator!=(obj); }
 
 PINLINE bool PString::operator<(const PObject & obj) const

--- a/include/ptlib/pstring.h
+++ b/include/ptlib/pstring.h
@@ -833,10 +833,32 @@ class PString : public PCharArray
        to other overloaded versions.
 
        @return
+       true if equal.
+     */
+    bool operator==(
+      const PString & str  ///< PString object to compare against.
+    ) const;
+
+    /**Compare two strings using the <code>PObject::Compare()</code> function. This
+       is identical to the <code>PObject</code> class function but is necessary due
+       to other overloaded versions.
+
+       @return
        true if not equal.
      */
     bool operator!=(
       const PObject & str  ///< PString object to compare against.
+    ) const;
+
+    /**Compare two strings using the <code>PObject::Compare()</code> function. This
+       is identical to the <code>PObject</code> class function but is necessary due
+       to other overloaded versions.
+
+       @return
+       true if not equal.
+     */
+    bool operator!=(
+      const PString & str  ///< PString object to compare against.
     ) const;
 
     /**Compare two strings using the <code>PObject::Compare()</code> function. This


### PR DESCRIPTION
Otherwise when compiling ptlib consumer code with C++ 20 compilation fails.