### PR TITLE
Work around missing ostream operator

### DIFF
--- a/include/ptlib/array.h
+++ b/include/ptlib/array.h
@@ -438,12 +438,25 @@ template <class T> class PBaseArray : public PAbstractArray
     }
   //@}
 
+  private:
+    template<typename X>
+    void streamOut(ostream & stream, const X & t) const
+    {
+      stream << t;
+    }
+
+    template<>
+    void streamOut<wchar_t>(ostream & stream, const wchar_t & t) const
+    {
+      stream << std::to_string(t);
+    }
+
   protected:
     virtual void PrintElementOn(
       ostream & stream,
       PINDEX index
     ) const {
-      stream << GetAt(index);
+      streamOut(stream, GetAt(index));
     }
 
     PBaseArray(PContainerReference & reference) : PAbstractArray(reference, sizeof(T)) { }

--- a/src/ptclib/asner.cxx
+++ b/src/ptclib/asner.cxx
@@ -1619,7 +1619,7 @@ void PASN_BMPString::PrintOn(ostream & strm) const
     PINDEX j;
     for (j = 0; j < 8; j++)
       if (i+j < sz)
-        strm << setw(4) << value[i+j] << ' ';
+        strm << setw(4) << std::to_string(value[i+j]) << ' ';
       else
         strm << "     ";
     strm << "  ";


### PR DESCRIPTION
In C++20 the narrow streams droped the `operator<<` overload for
wide-char types. See [operator<<(std::basic_ostream)](https://en.cppreference.com/w/cpp/io/basic_ostream/operator_ltlt2)

I'm unfamiliar with the ptlib code and do not know what a proper
replacement would be.