### PR TITLE
Add sndio sound backend

### DIFF
--- a/plugins/Makefile.in
+++ b/plugins/Makefile.in
@@ -51,6 +51,16 @@ DEFAULT_SOUND	= sound_esd
 endif
 endif
 
+##################################sndio
+HAS_SNDIO	= @HAS_SNDIO@
+
+ifeq (1,$(HAS_SNDIO))
+SUBDIRS += sound_sndio
+ifeq (,$(DEFAULT_SOUND))
+DEFAULT_SOUND	= sound_sndio
+endif
+endif
+
 #################################SundAudio
 HAS_SUNAUDIO = @HAS_SUNAUDIO@
 

--- a/plugins/configure
+++ b/plugins/configure
@@ -631,6 +631,7 @@ V4L2_CXXFLAGS
 HAS_V4L
 HAS_AUDIOSHM
 HAS_SUNAUDIO
+HAS_SNDIO
 HAS_PULSE
 HAS_OSS
 HAS_ESD
@@ -710,6 +711,7 @@ enable_alsa
 enable_esd
 enable_oss
 enable_pulse
+enable_sndio
 enable_sunaudio
 enable_shmaudio
 enable_video
@@ -1360,6 +1362,7 @@ disable plugin support]
   --enable-esd            enable ESD audio support
   --enable-oss            enable OSS audio support
   --enable-pulse       enable Pulse audio support
+  --enable-sndio          enable sndio audio support
   --enable-sunaudio            enable  Sun audio support
   --enable-shmaudio       enable shm audio support
   --disable-video         disable video device support
@@ -3928,6 +3931,35 @@ fi
 $as_echo_n "checking for Pulse sound support... " >&6; }
   if test "${PULSESNDCARDHDR}z" != "z"; then
     HAS_PULSE=1
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+  else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+  fi
+fi
+
+
+# Check whether --enable-sndio was given.
+if test "${enable_sndio+set}" = set; then :
+  enableval=$enable_sndio;
+else
+  enable_sndio=yes
+fi
+
+
+if test "${enable_sndio}z" = "yesz" ; then
+  ac_fn_c_check_header_mongrel "$LINENO" "sndio.h" "ac_cv_header_sndio_h" "$ac_includes_default"
+if test "x$ac_cv_header_sndio_h" = xyes; then :
+  SNDIOHDR=1
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sndio sound support" >&5
+$as_echo_n "checking for sndio sound support... " >&6; }
+  if test "${SNDIOHDR}z" != "z"; then
+    HAS_SNDIO=1
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }

--- a/plugins/configure.in
+++ b/plugins/configure.in
@@ -107,6 +107,23 @@ if test "${enable_pulse}z" = "yesz" ; then
 fi
 
 dnl #########################################################################
+dnl check for sndio sound support
+dnl ########################################################################
+
+AC_ARG_ENABLE(sndio, [  --enable-sndio          enable sndio audio support],,enable_sndio=yes)
+
+if test "${enable_sndio}z" = "yesz" ; then
+  AC_CHECK_HEADER(sndio.h, SNDIOHDR=1)
+  AC_MSG_CHECKING(for sndio sound support)
+  if test "${SNDIOHDR}z" != "z"; then
+    AC_SUBST(HAS_SNDIO, 1)
+    AC_MSG_RESULT(yes)
+  else
+    AC_MSG_RESULT(no)
+  fi
+fi
+
+dnl #########################################################################
 dnl check for sunaudio sound support
 dnl ########################################################################
 

--- a/plugins/sound_sndio/sound_sndio.cxx
+++ b/plugins/sound_sndio/sound_sndio.cxx
@@ -1,0 +1,495 @@
+/*
+ * sound_sndio.cxx
+ *
+ * Sound driver implementation.
+ *
+ * Portable Windows Library
+ *
+ * Copyright (c) 1993-1998 Equivalence Pty. Ltd.
+ *
+ * The contents of this file are subject to the Mozilla Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+ * the License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * The Original Code is Portable Windows Library.
+ *
+ * The initial developer of the sndio code is
+ * Jacob Meuser <jakemsr@sdf.lonestar.org>
+ *
+ * Portions are Copyright (C) 1993 Free Software Foundation, Inc.
+ * All Rights Reserved.
+ *
+ */
+
+#pragma implementation "sound_sndio.h"
+
+#include "sound_sndio.h"
+
+#include <sys/poll.h>
+
+PCREATE_SOUND_PLUGIN(SNDIO, PSoundChannelSNDIO);
+
+PSoundChannelSNDIO::PSoundChannelSNDIO()
+{
+  PSoundChannelSNDIO::Construct();
+}
+
+
+PSoundChannelSNDIO::PSoundChannelSNDIO(const PString & device,
+                                        Directions dir,
+                                          unsigned numChannels,
+                                          unsigned sampleRate,
+                                          unsigned bitsPerSample)
+{
+  Construct();
+  Open(device, dir, numChannels, sampleRate, bitsPerSample);
+}
+
+
+void PSoundChannelSNDIO::Construct()
+{
+  os_handle = -1;
+  hdl = NULL;
+}
+
+
+PSoundChannelSNDIO::~PSoundChannelSNDIO()
+{
+  Close();
+}
+
+
+PStringArray PSoundChannelSNDIO::GetDeviceNames(Directions)
+{
+  static const char * const devices[] = {
+    "default",
+    "/dev/audio0",
+    "/dev/audio1",
+    "/dev/audio2"
+  };
+
+  return PStringArray(PARRAYSIZE(devices), devices);
+}
+
+
+PString PSoundChannelSNDIO::GetDefaultDevice(Directions dir)
+{
+  return "default";
+}
+
+PBoolean PSoundChannelSNDIO::Open(const PString & device,
+                              Directions dir,
+                                unsigned numChannels,
+                                unsigned sampleRate,
+                                unsigned bitsPerSample)
+{
+  uint mode;
+  char sio_device[32];
+
+  Close();
+
+  if (dir == Recorder)
+    mode = SIO_REC;
+  else
+    mode = SIO_PLAY;
+
+  snprintf(sio_device, 32, "%s", (const char *)device);
+
+  if (strncmp(sio_device, "default", 7) == 0)
+    hdl = sio_open(NULL, mode, 0);
+  else
+    hdl = sio_open(sio_device, mode, 0);
+
+  if (hdl == NULL) {
+    printf("sio_open failed\n");
+    return FALSE;
+  }
+
+  mDirection     = dir;
+  mDevice        = device;
+  mSampleRate    = sampleRate;
+  mNumChannels   = numChannels;
+  mBitsPerSample = bitsPerSample;
+  mBytesPerFrame = (bitsPerSample / 8) * numChannels;
+
+  isInitialised = FALSE;
+
+  return TRUE;
+}
+
+PBoolean PSoundChannelSNDIO::Setup()
+{
+  if (!hdl) {
+    PTRACE(6, "SNDIO\tSkipping setup of " << mDevice << " as not open");
+    return FALSE;
+  }
+
+  if (isInitialised) {
+    PTRACE(6, "SNDIO\tSkipping setup of " << mDevice << " as instance already initialised");
+    return TRUE;
+  }
+
+  PTRACE(6, "SNDIO\tInitialising " << mDevice);
+
+  sio_initpar(&par);
+
+  int framesPerFrag = mFragSize / mBytesPerFrame;
+  par.bufsz = mFragCount * framesPerFrag;
+  par.round = framesPerFrag;
+
+  par.bits = mBitsPerSample;
+  par.sig = 1;
+#if PBYTE_ORDER == PLITTLE_ENDIAN
+  par.le = 1;
+#else
+  par.le = 0;
+#endif
+
+  if (mDirection == Recorder)
+    par.rchan = mNumChannels;
+  else
+    par.pchan = mNumChannels;
+
+  par.rate = mSampleRate;
+
+  if (!sio_setpar(hdl, &par)) {
+    printf("sio_setpar failed\n");
+    return FALSE;
+  }
+
+  if (!sio_getpar(hdl, &par)) {
+    printf("sio_getpar failed\n");
+    return FALSE;
+  }
+
+  mFragSize = par.round * mBytesPerFrame;
+  mFragCount = par.bufsz / par.round;
+
+  if (!sio_start(hdl)) {
+    printf("sio_start failed\n");
+    return FALSE;
+  }
+
+  isInitialised = TRUE;
+
+  return TRUE;
+}
+
+PBoolean PSoundChannelSNDIO::Close()
+{
+  if (!hdl)
+    return TRUE;
+
+  sio_close(hdl);
+  hdl = NULL;
+  return PChannel::Close();
+}
+
+PBoolean PSoundChannelSNDIO::IsOpen() const
+{
+  return (hdl != NULL);
+}
+
+PBoolean PSoundChannelSNDIO::Write(const void * buf, PINDEX len)
+{
+  lastWriteCount = 0;
+
+  if (!Setup() || !hdl)
+    return FALSE;
+
+  int did, tot = 0;
+
+  while (len > 0) {
+    did = sio_write(hdl, (void *)buf, len);
+    if (did == 0) {
+      printf("sio_write failed\n");
+      return FALSE;
+    }
+    len -= did;
+    buf = (char*)buf + did;
+    tot += did;
+  }
+  lastWriteCount += tot;
+
+  return TRUE;
+}
+
+PBoolean PSoundChannelSNDIO::Read(void * buf, PINDEX len)
+{
+  lastReadCount = 0;
+
+  if (!Setup() || !hdl)
+    return FALSE;
+
+  int did, tot = 0;
+
+  while (len > 0) {
+    did = sio_read(hdl, buf, len);
+    if (did == 0) {
+      printf("sio_read failed\n");
+      return FALSE;
+    }
+    len -= did;
+    buf = (char*)buf + did;
+    tot += did;
+  }
+  lastReadCount += tot;
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::SetFormat(unsigned numChannels,
+                              unsigned sampleRate,
+                              unsigned bitsPerSample)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  PAssert((bitsPerSample == 8) || (bitsPerSample == 16), PInvalidParameter);
+  PAssert(numChannels >= 1 && numChannels <= 2, PInvalidParameter);
+
+  if (isInitialised) {
+    if ((numChannels   != mNumChannels) ||
+        (sampleRate    != mSampleRate) ||
+        (bitsPerSample != mBitsPerSample)) {
+      PTRACE(6, "SNDIO\tTried to change read/write format without stopping");
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  mNumChannels   = numChannels;
+  mSampleRate    = sampleRate;
+  mBitsPerSample = bitsPerSample;
+  isInitialised  = FALSE;
+
+  return TRUE;
+}
+
+
+unsigned PSoundChannelSNDIO::GetChannels()   const
+{
+  return mNumChannels;
+}
+
+
+unsigned PSoundChannelSNDIO::GetSampleRate() const
+{
+  return mSampleRate;
+}
+
+
+unsigned PSoundChannelSNDIO::GetSampleSize() const
+{
+  return mBitsPerSample;
+}
+
+
+PBoolean PSoundChannelSNDIO::SetBuffers(PINDEX size, PINDEX count)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  PAssert(size > 0 && count > 0 && count < 65536, PInvalidParameter);
+
+  if (isInitialised) {
+    if (mFragSize != (unsigned)size || mFragCount != (unsigned)count) {
+      PTRACE(6, "SNDIO\tTried to change buffers without stopping");
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  mFragSize = size;
+  mFragCount = count;
+  isInitialised = FALSE;
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::GetBuffers(PINDEX & size, PINDEX & count)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  count = mFragCount;
+  size = mFragSize;
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::PlaySound(const PSound & sound, PBoolean wait)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  if (!Write((const BYTE *)sound, sound.GetSize()))
+    return FALSE;
+
+  if (wait)
+    return WaitForPlayCompletion();
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::PlayFile(const PFilePath & filename, PBoolean wait)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  PFile file(filename, PFile::ReadOnly);
+  if (!file.IsOpen())
+    return FALSE;
+
+  for (;;) {
+    BYTE buffer[256];
+    if (!file.Read(buffer, 256))
+      break;
+    PINDEX len = file.GetLastReadCount();
+    if (len == 0)
+      break;
+    if (!Write(buffer, len))
+      break;
+  }
+
+  file.Close();
+
+  if (wait)
+    return WaitForPlayCompletion();
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::HasPlayCompleted()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::WaitForPlayCompletion()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::RecordSound(PSound & sound)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  return FALSE;
+}
+
+
+PBoolean PSoundChannelSNDIO::RecordFile(const PFilePath & filename)
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  return FALSE;
+}
+
+
+PBoolean PSoundChannelSNDIO::StartRecording()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::IsRecordBufferFull()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  struct pollfd pfd;
+  int events = POLLIN;
+  sio_pollfd(hdl, &pfd, events);
+  return ConvertOSError(::poll(&pfd, 1, 0));
+}
+
+
+PBoolean PSoundChannelSNDIO::AreAllRecordBuffersFull()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  struct pollfd pfd;
+  int events = POLLIN;
+  sio_pollfd(hdl, &pfd, events);
+  return ConvertOSError(::poll(&pfd, 1, 0));
+}
+
+
+PBoolean PSoundChannelSNDIO::WaitForRecordBufferFull()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  // return PXSetIOBlock(PXReadBlock, readTimeout);
+
+  struct pollfd pfd;
+  int events = POLLIN;
+  sio_pollfd(hdl, &pfd, events);
+  return ConvertOSError(::poll(&pfd, 1, 1000));
+}
+
+
+PBoolean PSoundChannelSNDIO::WaitForAllRecordBuffersFull()
+{
+  if (!hdl)
+    return SetErrorValues(NotOpen, EBADF);
+
+  struct pollfd pfd;
+  int events = POLLIN;
+  sio_pollfd(hdl, &pfd, events);
+  return ConvertOSError(::poll(&pfd, 1, 1000));
+}
+
+
+PBoolean PSoundChannelSNDIO::Abort()
+{
+  return TRUE;
+}
+
+
+PBoolean PSoundChannelSNDIO::SetVolume(unsigned newVal)
+{
+  if (!hdl)
+    return FALSE;
+
+  return FALSE;
+}
+
+
+PBoolean  PSoundChannelSNDIO::GetVolume(unsigned &devVol)
+{
+  if (!hdl)
+    return FALSE;
+
+  devVol = 0;
+  return FALSE;
+}
+  
+
+
+// End of file

--- a/plugins/sound_sndio/sound_sndio.h
+++ b/plugins/sound_sndio/sound_sndio.h
@@ -1,0 +1,65 @@
+#include <ptlib.h>
+#include <ptlib/sound.h>
+#include <ptlib/socket.h>
+
+#include <sndio.h>
+
+class PSoundChannelSNDIO: public PSoundChannel
+{
+ public:
+    PSoundChannelSNDIO();
+    void Construct();
+    PSoundChannelSNDIO(const PString &device,
+                     PSoundChannel::Directions dir,
+                     unsigned numChannels,
+                     unsigned sampleRate,
+		     unsigned bitsPerSample);
+    ~PSoundChannelSNDIO();
+    static PStringArray GetDeviceNames(PSoundChannel::Directions = Player);
+    static PString GetDefaultDevice(PSoundChannel::Directions);
+    PBoolean Open(const PString & _device,
+              Directions _dir,
+              unsigned _numChannels,
+              unsigned _sampleRate,
+              unsigned _bitsPerSample);
+    PBoolean Setup();
+    PBoolean Close();
+    PBoolean IsOpen() const;
+    PBoolean Write(const void * buf, PINDEX len);
+    PBoolean Read(void * buf, PINDEX len);
+    PBoolean SetFormat(unsigned numChannels,
+                   unsigned sampleRate,
+                   unsigned bitsPerSample);
+    unsigned GetChannels() const;
+    unsigned GetSampleRate() const;
+    unsigned GetSampleSize() const;
+    PBoolean SetBuffers(PINDEX size, PINDEX count);
+    PBoolean GetBuffers(PINDEX & size, PINDEX & count);
+    PBoolean PlaySound(const PSound & sound, PBoolean wait);
+    PBoolean PlayFile(const PFilePath & filename, PBoolean wait);
+    PBoolean HasPlayCompleted();
+    PBoolean WaitForPlayCompletion();
+    PBoolean RecordSound(PSound & sound);
+    PBoolean RecordFile(const PFilePath & filename);
+    PBoolean StartRecording();
+    PBoolean IsRecordBufferFull();
+    PBoolean AreAllRecordBuffersFull();
+    PBoolean WaitForRecordBufferFull();
+    PBoolean WaitForAllRecordBuffersFull();
+    PBoolean Abort();
+    PBoolean SetVolume(unsigned newVal);
+    PBoolean GetVolume(unsigned &devVol);
+
+  protected:
+    struct sio_hdl *hdl;
+    struct sio_par par;
+    unsigned mNumChannels;
+    unsigned mSampleRate;
+    unsigned mBitsPerSample;
+    unsigned mFragCount;
+    unsigned mFragSize;
+    unsigned mBytesPerFrame;
+    Directions mDirection;
+    PString mDevice;
+    PBoolean isInitialised;
+};


### PR DESCRIPTION
sndio is the native sound API used by OpenBSD, but is also ported to
run on other *BSD and Linux.