### PR TITLE
Simplify OSS header handling

### DIFF
--- a/plugins/sound_esd/sound_esd.h
+++ b/plugins/sound_esd/sound_esd.h
@@ -7,20 +7,8 @@
 //#include <ptlib/contain.inl>
 //#endif
 
-#ifdef P_LINUX
+#if defined(P_LINUX) || defined(P_FREEBSD) || defined(P_NETBSD)
 #include <sys/soundcard.h>
-#endif
-
-#ifdef P_FREEBSD
-#if P_FREEBSD >= 500000
-#include <sys/soundcard.h>
-#else
-#include <machine/soundcard.h>
-#endif
-#endif
-
-#if defined(P_OPENBSD) || defined(P_NETBSD)
-#include <soundcard.h>
 #endif
 
 class PSoundChannelESD: public PSoundChannel

--- a/plugins/sound_oss/sound_oss.h
+++ b/plugins/sound_oss/sound_oss.h
@@ -7,24 +7,8 @@
 //#include <ptlib/contain.inl>
 //#endif
 
-#ifdef P_SOLARIS
+#if defined(P_LINUX) || defined(P_OPENBSD) || defined(P_NETBSD) || defined(P_SOLARIS)
 #include <sys/soundcard.h>
-#endif
-
-#ifdef P_LINUX
-#include <sys/soundcard.h>
-#endif
-
-#ifdef P_FREEBSD
-#if P_FREEBSD >= 500000
-#include <sys/soundcard.h>
-#else
-#include <machine/soundcard.h>
-#endif
-#endif
-
-#if defined(P_OPENBSD) || defined(P_NETBSD)
-#include <soundcard.h>
 #endif
 
 class SoundHandleEntry : public PObject {

--- a/plugins/sound_pulse/sound_pulse.h
+++ b/plugins/sound_pulse/sound_pulse.h
@@ -7,24 +7,8 @@
 //#include <ptlib/contain.inl>
 //#endif
 
-#ifdef P_SOLARIS
+#if defined(P_LINUX) || defined(P_OPENBSD) || defined(P_NETBSD) || defined(P_SOLARIS)
 #include <sys/soundcard.h>
-#endif
-
-#ifdef P_LINUX
-#include <sys/soundcard.h>
-#endif
-
-#ifdef P_FREEBSD
-#if P_FREEBSD >= 500000
-#include <sys/soundcard.h>
-#else
-#include <machine/soundcard.h>
-#endif
-#endif
-
-#if defined(P_OPENBSD) || defined(P_NETBSD)
-#include <soundcard.h>
 #endif
 
 #include <pulse/stream.h>

--- a/src/ptlib/unix/ossaix.cxx
+++ b/src/ptlib/unix/ossaix.cxx
@@ -36,16 +36,11 @@
 #include <ptlib.h>
 
 #ifdef P_LINUX
-#include <sys/soundcard.h>
 #include <sys/time.h>
 #endif
 
-#ifdef P_FREEBSD
-#include <machine/soundcard.h>
-#endif
-
-#if defined(P_OPENBSD) || defined(P_NETBSD)
-#include <soundcard.h>
+#if defined(P_LINUX) || defined(P_FREEBSD) || defined(P_NETBSD)
+#include <sys/soundcard.h>
 #endif
 
 


### PR DESCRIPTION
OpenBSD does not use OSS any longer. NetBSD has the header in sys/ as well. FreeBSD 4.x and older are 20+ years old.