### PR TITLE
Fix incorrect uses of memcpy. Fix parsing SOCKS port.

### DIFF
--- a/src/ptclib/cypher.cxx
+++ b/src/ptclib/cypher.cxx
@@ -678,7 +678,11 @@ void PMessageDigest5::Complete(Code & codeResult)
 {
   Result result;
   InternalCompleteDigest(result);
-  memcpy(codeResult.value, result.GetPointer(), sizeof(codeResult.value));
+
+  const PUInt32l *res = (const PUInt32l *)
+    result.value.GetPointer(PARRAYSIZE(codeResult.value) * sizeof(PUInt32l));
+  for (PINDEX i = 0; i < PARRAYSIZE(codeResult.value); ++i)
+    codeResult.value[i] = res[i];
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ptclib/socks.cxx
+++ b/src/ptclib/socks.cxx
@@ -678,7 +678,7 @@ PBoolean PSocksUDPSocket::ReadFrom(void * buf, PINDEX len, Address & addr, WORD 
 
     case SOCKS_ADDR_IPV4 :
       addr = Address(4, &newbuf[4]);
-      port_pos = 4;
+      port_pos = 4+4;
       break;
 
     default :

--- a/src/ptclib/socks.cxx
+++ b/src/ptclib/socks.cxx
@@ -677,7 +677,7 @@ PBoolean PSocksUDPSocket::ReadFrom(void * buf, PINDEX len, Address & addr, WORD 
       break;
 
     case SOCKS_ADDR_IPV4 :
-      memcpy(&addr, &newbuf[4], 4);
+      addr = Address(4, &newbuf[4]);
       port_pos = 4;
       break;
 

--- a/src/ptlib/unix/socket.cxx
+++ b/src/ptlib/unix/socket.cxx
@@ -825,7 +825,7 @@ PBoolean PEthSocket::Connect(const PString & interfaceName)
   if (!ConvertOSError(ioctl(ifsock.GetHandle(), SIO_Get_MAC_Address, &ifr)))
     return PFalse;
 
-  memcpy(&macAddress, ifr.ifr_macaddr, sizeof(macAddress));
+  macAddress = PEthSocket::Address((BYTE *)ifr.ifr_macaddr);
 #endif
 
   channelName = interfaceName;


### PR DESCRIPTION
This PR contains two fixes:

1. `memcpy` was being used to assign objects of non-trivially-copyable types. This resulted in gcc 11 warnings like these:

```
ptclib/socks.cxx: In member function 'virtual PBoolean PSocksUDPSocket::ReadFrom(void*, PINDEX, PIPSocket::Address&, WORD&)':
ptclib/socks.cxx:680:13: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'class PIPSocket::Address' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
  680 |       memcpy(&addr, &newbuf[4], 4);
      |       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /build/libpt/ptlib/include/ptlib/sockets.h:51,
                 from /build/libpt/ptlib/include/ptclib/socks.h:39,
                 from ptclib/socks.cxx:35:
/build/libpt/ptlib/include/ptlib/ipsock.h:75:11: note: 'class PIPSocket::Address' declared here
   75 |     class Address : public PObject {
      |           ^~~~~~~

ptlib/unix/socket.cxx: In member function 'virtual PBoolean PEthSocket::Connect(const PString&)':
ptlib/unix/socket.cxx:828:9: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'union PEthSocket::Address' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
  828 |   memcpy(&macAddress, ifr.ifr_macaddr, sizeof(macAddress));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /build/libpt/ptlib/include/ptlib/sockets.h:81,
                 from ptlib/unix/socket.cxx:44:
/build/libpt/ptlib/include/ptlib/ethsock.h:79:11: note: 'union PEthSocket::Address' declared here
   79 |     union Address {
      |           ^~~~~~~

ptclib/cypher.cxx: In member function 'virtual void PMessageDigest5::Complete(PMessageDigest5::Code&)':
ptclib/cypher.cxx:681:9: warning: 'void* memcpy(void*, const void*, size_t)' writing to an object of type 'PUInt32l' {aka 'struct PIntSameOrder<unsigned int>'} with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
  681 |   memcpy(codeResult.value, result.GetPointer(), sizeof(codeResult.value));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /build/libpt/ptlib/include/ptlib/psync.h:43,
                 from /build/libpt/ptlib/include/ptlib/critsec.h:34,
                 from /build/libpt/ptlib/include/ptlib/contain.h:42,
                 from /build/libpt/ptlib/include/ptlib.h:56,
                 from ptclib/cypher.cxx:37:
/build/libpt/ptlib/include/ptlib/object.h:1371:8: note: 'PUInt32l' {aka 'struct PIntSameOrder<unsigned int>'} declared here
 1371 | struct PIntSameOrder {
      |        ^~~~~~~~~~~~~
```

In case of `PIPSocket::Address`, the warning indicates a genuine bug as `memcpy` overwrites the vtable pointer that is in the beginning of `Address`.

2. In SOCKS implementation, the port after IPv4 address was being parsed at an incorrect position. It should be immediately after the address.
