### PR TITLE
Remove memory allocation function overrides

### DIFF
--- a/src/ptlib/common/object.cxx
+++ b/src/ptlib/common/object.cxx
@@ -944,35 +944,6 @@ void PMemoryHeap::SetAllocationBreakpoint(DWORD objectNumber)
   _CrtSetBreakAlloc(objectNumber);
 }
 
-
-#else // defined(_MSC_VER) && defined(_DEBUG)
-
-#if !defined(P_VXWORKS) && !defined(_WIN32_WCE)
-
-#if (__cplusplus >= 201703L) // C++17
-void* operator new[](std::size_t nSize, std::align_val_t al) noexcept(false)
-#else
-#if (__GNUC__ >= 3) || ((__GNUC__ == 2)&&(__GNUC_MINOR__ >= 95)) //2.95.X & 3.X
-void * operator new[](size_t nSize) throw ()
-#else
-void * operator new[](size_t nSize)
-#endif
-#endif
-{
-  return malloc(nSize);
-}
-
-#if (__GNUC__ >= 3) || ((__GNUC__ == 2)&&(__GNUC_MINOR__ >= 95)) //2.95.X & 3.X
-void operator delete[](void * ptr) throw ()
-#else
-void operator delete[](void * ptr)
-#endif
-{
-  free(ptr);
-}
-
-#endif // !P_VXWORKS
-
 #endif // defined(_MSC_VER) && defined(_DEBUG)
 
 #endif // PMEMORY_CHECK


### PR DESCRIPTION
The `operator new[]` and `operator delete[]` were inconsistently defined and violated the intended behavior of these functions defined by the C++ standard (in particular, `operator new[]` would return null instead of throwing `std::bad_alloc` in case of failure). This would break any code that relied on the standard behavior (this includes the standard library and user's code). Furthermore, non-array versions of these functions were missing.

Given that there is no clear purpose of these overrides, it's better to remove these overrides instead of trying to fix them.

Closes https://github.com/willamowius/ptlib/issues/34.