### PR TITLE
Fixed handling of --extern-dir in configure program

### DIFF
--- a/src/ptlib/msos/svcproc.cxx
+++ b/src/ptlib/msos/svcproc.cxx
@@ -215,7 +215,7 @@ class PSystemLogToEvent : public PSystemLogTarget
 
     char thrdbuf[16];
     if (threadName.IsEmpty())
-      sprintf(thrdbuf, "0x%08X", thread);
+      sprintf(thrdbuf, "0x%p", thread);
     else {
       strncpy(thrdbuf, threadName, sizeof(thrdbuf)-1);
       thrdbuf[sizeof(thrdbuf)-1] = '\0';


### PR DESCRIPTION
* When specifying an --extern-dir option, the program searches for files based on the given directory. Previously it would only search in subdirectories of the specified path, not the path itself.
* The trailing backslash on the --extern-dir option is now optional.
* It's now possible to specify multiple --extern-dir arguments. See below.
* Using --extern-dir sets searchDisk to true, undoing any previous --no-search parameter.
* When specifying --extern-dir, the specified directory is not checked against the list of excluded directories. See below.

The externDir variable that previously held the text behind the --extern-dir parameter, was replaced by a list<string>externDirs, and each occurrence of --extern-dir adds to the list and sets searchDisk to true.

By default, searchDisk is true and the externDirs list is empty. If the command line arguments don't change that, the list is filled with the root directories of all hard disks in the system. Previously, if there were no hard disks in the system, the code would add "C:\" but that code had a bug (there was no extra \0 in memory after "C:\\" so it would use random data from the stack) so it never worked anyway. Now the code just leaves the list empty and behaves as if --no-search was specified, if there are no hard disks in the system.

The most important change is that Locate is called from TreeWalk before recursing into subdirectories, not after. However, the DirExcluded function is only called when recursing. I did this on purpose so that if the user specifies an exclude-dir and an extern-dir that's under that exclude-dir, the specified directory is searched with Locate (but subdirectories are not recursed). For example: --exclude-dir=D:\ --extern-dir=D:\mystuff will search D:\mystuff but not D:\mystuff\myotherstuff.

I also added some code to send some diagnostic messages to cout, and I fixed a compiler warning in the svcproc.cxx module.