### PR TITLE
PTLIB build system cleanup and update to OpenSSL include files

### DIFF
--- a/include/ptbuildopts.h.in
+++ b/include/ptbuildopts.h.in
@@ -301,6 +301,9 @@
     #pragma include_alias(<openssl/x509err.h>,    <@SSL_DIR@/include/openssl/x509err.h>)
     #pragma include_alias(<openssl/x509v3.h>,     <@SSL_DIR@/include/openssl/x509v3.h>)
     #pragma include_alias(<openssl/x509v3err.h>,  <@SSL_DIR@/include/openssl/x509v3err.h>)
+    #pragma include_alias(<openssl/e_ostime.h>,   <@SSL_DIR@/include/openssl/e_ostime.h>)
+    #pragma include_alias(<openssl/indicator.h>,  <@SSL_DIR@/include/openssl/indicator.h>)
+    #pragma include_alias(<openssl/quic.h>,       <@SSL_DIR@/include/openssl/quic.h>)
 
     #ifdef _WIN64
       #ifdef _DEBUG


### PR DESCRIPTION
Cleaned up the PTLIB build system. NOTE! Output file locations have changed!

For more detailed information, see the commit comments. Please note: Github is very confused about the changes to the line endings that Visual Studio generated in the solution and project files. If you want to study the differences, use a tool like GitExtensions and set the view to ignore line-end differences. 

* Removed the x64 build from all projects. The X64 build would fail anyway right now. I can add it back later.
* Changed OutDir and IntDir in all projects separate output files in a sensible way that makes it unnecessary to use many file name overrides
* Changed TargetName of the ptlib project to "ptlibs" (all lower case) for better consistency
* Changed the custom build step for ptbuildopts.h.in so it actually works "out of the box" without depending on %path%
* Removed unnecessary text and settings from project files and solution file
* Made some small changes to a couple of source files so the include "regex.h" without settings overrides
* Some previously incorrectly removed projects were cleaned out of the solution file

A similar cleanup of the H323Plus repo will follow.
