### PR TITLE
Added incliude-aliases for latest OpenSSL

### DIFF
--- a/include/ptbuildopts.h.in
+++ b/include/ptbuildopts.h.in
@@ -301,6 +301,9 @@
     #pragma include_alias(<openssl/x509err.h>,    <@SSL_DIR@/include/openssl/x509err.h>)
     #pragma include_alias(<openssl/x509v3.h>,     <@SSL_DIR@/include/openssl/x509v3.h>)
     #pragma include_alias(<openssl/x509v3err.h>,  <@SSL_DIR@/include/openssl/x509v3err.h>)
+    #pragma include_alias(<openssl/e_ostime.h>,   <@SSL_DIR@/include/openssl/e_ostime.h>)
+    #pragma include_alias(<openssl/indicator.h>,  <@SSL_DIR@/include/openssl/indicator.h>)
+    #pragma include_alias(<openssl/quic.h>,       <@SSL_DIR@/include/openssl/quic.h>)
 
     #ifdef _WIN64
       #ifdef _DEBUG


### PR DESCRIPTION
This allows building PTLIB/H323Plus with the latest OpenSSL header files (3.5.0).

If the system has any older versions of OpenSSL that are supported by PTLib, the additional include_aliases will have no effect; files that aren't included don't have to be redirected.

(I'm working on redoing the build changes that I tried to submit earlier; they will be submitted later today).